### PR TITLE
fixes #2 - add ability to enable/disable using stream instead of index

### DIFF
--- a/Multiplex.cpp
+++ b/Multiplex.cpp
@@ -30,6 +30,7 @@ void Multiplex::reset()
 
 bool Multiplex::add(Print * stream)
 {
+  if (index(stream) != 0xFF) return false;
   if (_count >= _size) return false;
   _enabled[_count]  = true;
   _stream[_count++] = stream;
@@ -77,36 +78,36 @@ uint8_t Multiplex::index(Print *stream)
       return i;
     }
   }
-  return i;
+  return 0xFF;
 }
 
 void Multiplex::enable(uint8_t n)
 {
-  if (n < _count) _enabled[n] = true;
+  if (n != 0xFF && n < _count) _enabled[n] = true;
 }
 
-void Multiplex::enable(Print *stream)
+void Multiplex::enableStream(Print *stream)
 {
   return enable(index(stream));
 }
 
 void Multiplex::disable(uint8_t n)
 {
-  if (n < _count) _enabled[n] = false;
+  if (n != 0xFF && n < _count) _enabled[n] = false;
 }
 
-void Multiplex::disable(Print *stream)
+void Multiplex::disableStream(Print *stream)
 {
   return disable(index(stream));
 }
 
 bool Multiplex::isEnabled(uint8_t n)
 {
-  if (n >= _count) return false;
+  if (n != 0xFF && n >= _count) return false;
   return _enabled[n];
 }
 
-bool Multiplex::isEnabled(Print *stream)
+bool Multiplex::isEnabledStream(Print *stream)
 {
   return isEnabled(index(stream));
 }

--- a/Multiplex.cpp
+++ b/Multiplex.cpp
@@ -53,23 +53,49 @@ size_t Multiplex::write(uint8_t c)
   return n;
 }
 
+// private
+uint8_t Multiplex::index(Print *stream) 
+{
+  uint8_t i = 0;
+  for (; i < _count; i++)
+  {
+    if (stream == _stream[i]) 
+    {
+      return i;
+    }
+  }
+  return i;
+}
 
 void Multiplex::enable(uint8_t n)
 {
   if (n < _count) _enabled[n] = true;
 }
 
+void Multiplex::enable(Print *stream)
+{
+  return enable(index(stream));
+}
 
 void Multiplex::disable(uint8_t n)
 {
   if (n < _count) _enabled[n] = false;
 }
 
+void Multiplex::disable(Print *stream)
+{
+  return disable(index(stream));
+}
 
 bool Multiplex::isEnabled(uint8_t n)
 {
   if (n >= _count) return false;
   return _enabled[n];
+}
+
+bool Multiplex::isEnabled(Print *stream)
+{
+  return isEnabled(index(stream));
 }
 
 // -- END OF FILE --

--- a/Multiplex.cpp
+++ b/Multiplex.cpp
@@ -83,7 +83,7 @@ uint8_t Multiplex::index(Print *stream)
 
 void Multiplex::enable(uint8_t n)
 {
-  if (n != 0xFF && n < _count) _enabled[n] = true;
+  if (n < _count && n != 0xFF) _enabled[n] = true;
 }
 
 void Multiplex::enableStream(Print *stream)

--- a/Multiplex.cpp
+++ b/Multiplex.cpp
@@ -1,13 +1,14 @@
 //
 //    FILE: Multiplex.cpp
 //  AUTHOR: Rob Tillaart
-// VERSION: 0.1.0
+// VERSION: 0.2.0
 // PURPOSE: Arduino library to multiplex streams
 //    DATE: 2021-01-09
 //     URL: https://github.com/RobTillaart/Multiplex
 //
 //  HISTORY:
 //  0.1.0   2021-01-09  initial version
+//  0.2.0   2021-08-09  See issues #2 and #3
 
 
 #include "Multiplex.h"
@@ -48,6 +49,18 @@ size_t Multiplex::write(uint8_t c)
     if (_enabled[i])
     {
       n += _stream[i]->write(c);
+    }
+  }
+  return n;
+}
+
+size_t Multiplex::write(const uint8_t *buffer, size_t size) {
+  uint8_t n = 0;
+  for (uint8_t i = 0; i < _count; i++)
+  {
+    if (_enabled[i])
+    {
+      n += _stream[i]->write(buffer, size);
     }
   }
   return n;

--- a/Multiplex.h
+++ b/Multiplex.h
@@ -32,14 +32,18 @@ public:
   uint8_t count()       { return _count; };
   uint8_t size()        { return _size; };
   void    enable(uint8_t index);
+  void    enable(Print * stream);
   void    disable(uint8_t index);
+  void    disable(Print * stream);
   bool    isEnabled(uint8_t index);
+  bool    isEnabled(Print * stream);
 
 private:
   Print * _stream[MAX_MULTIPLEX];
   bool    _enabled[MAX_MULTIPLEX];  // bitmask max 4 ...
   uint8_t _count;
   uint8_t _size;
+  uint8_t index(Print *stream);
 };
 
 // -- END OF FILE --

--- a/Multiplex.h
+++ b/Multiplex.h
@@ -2,17 +2,17 @@
 //
 //    FILE: Multiplex.h
 //  AUTHOR: Rob Tillaart
-// VERSION: 0.1.0
+// VERSION: 0.2.0
 // PURPOSE: Arduino library to multiplex streams 
 //    DATE: 2021-01-09
 //     URL: https://github.com/RobTillaart/Multiplex
 
 
 #include "Arduino.h"
-#include "Print.h"
+//#include "Print.h"
 
 
-#define MULTIPLEX_LIB_VERSION      (F("0.1.0"))
+#define MULTIPLEX_LIB_VERSION      (F("0.2.0"))
 
 
 const uint8_t MAX_MULTIPLEX = 4;
@@ -24,7 +24,8 @@ public:
   Multiplex();
   
   // CORE
-  size_t  write(uint8_t c);
+  virtual size_t  write(uint8_t c) override;
+  virtual size_t write(const uint8_t *buffer, size_t size) override;
   bool    add(Print * stream);  // returns true on success
   void    reset();
 

--- a/Multiplex.h
+++ b/Multiplex.h
@@ -33,11 +33,11 @@ public:
   uint8_t count()       { return _count; };
   uint8_t size()        { return _size; };
   void    enable(uint8_t index);
-  void    enable(Print * stream);
+  void    enableStream(Print * stream);
   void    disable(uint8_t index);
-  void    disable(Print * stream);
+  void    disableStream(Print * stream);
   bool    isEnabled(uint8_t index);
-  bool    isEnabled(Print * stream);
+  bool    isEnabledStream(Print * stream);
 
 private:
   Print * _stream[MAX_MULTIPLEX];

--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ Returns false if no space left.
 - **uint8_t count()** returns # streams, MAX 4 in initial release
 - **uint8_t size()** returns size which is 4 in the current release.
 - **void enable(uint8_t index)** enable the stream at index.
-- **void enable(Stream * stream)** enable the stream.
+- **void enableStream(Stream * stream)** enable the stream.
 - **void disable(uint8_t index)** disable the stream at index.
-- **void disable(Stream * stream)** disable the stream.
+- **void disableStream(Stream * stream)** disable the stream.
 - **bool isEnabled(uint8_t index)** checks if the stream at index is enabled.
-- **bool isEnabled(Stream * stream)** checks if the stream is enabled.
+- **bool isEnabledStream(Stream * stream)** checks if the stream is enabled.
 
 
 ## Future

--- a/README.md
+++ b/README.md
@@ -3,22 +3,25 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/RobTillaart/Multiplex/blob/master/LICENSE)
 [![GitHub release](https://img.shields.io/github/release/RobTillaart/Multiplex.svg?maxAge=3600)](https://github.com/RobTillaart/Multiplex/releases)
 
-
 # Multiplex
 
 Arduino Library implementing a stream multiplexer.
 
-
 ## Description
 
 Multiplex is a library in which one can add multiple Print streams. 
+
 If one prints to the multiplexer it is sent to all the streams that were added.
-The maximum nr of streams to add is 4 .
+
+The maximum nr of streams to add is 4.
+
 It is possible to disable individual streams.
 
+Streams can be enabled or disabled by calling `enable()/disable()` passing either an index (based on the order 
+in whicbh `add` was called; 0 is first) or a pointer to the `Print` 
+object that was passed to `add(Print *)`;
 
 ## Interface
-
 
 ### Constructor
 
@@ -37,8 +40,11 @@ Returns false if no space left.
 - **uint8_t count()** returns # streams, MAX 4 in initial release
 - **uint8_t size()** returns size which is 4 in the current release.
 - **void enable(uint8_t index)** enable the stream at index.
+- **void enable(Stream * stream)** enable the stream.
 - **void disable(uint8_t index)** disable the stream at index.
+- **void disable(Stream * stream)** disable the stream.
 - **bool isEnabled(uint8_t index)** checks if the stream at index is enabled.
+- **bool isEnabled(Stream * stream)** checks if the stream is enabled.
 
 
 ## Future

--- a/examples/Multiplex_softwareSerial/Multiplex_softwareSerial.ino
+++ b/examples/Multiplex_softwareSerial/Multiplex_softwareSerial.ino
@@ -6,7 +6,7 @@
 //    DATE: 2021-01-17
 
 #include "Multiplex.h"
-#include "SoftwareSerial.h"
+#include <SoftwareSerial.h>
 
 // one multiplexer
 Multiplex mp;
@@ -41,7 +41,19 @@ void setup()
   Serial.print("count: ");
   Serial.println(n);
 
-  mp.println("\n Done...\n");
+  mp.disable(&Serial_B);
+
+  for (int i = 0; i < mp.count(); i++)
+  {
+    Serial.print("isEnabled ");
+    Serial.print(i);
+    Serial.print(":\t");
+    Serial.println(mp.isEnabled(i));
+  }
+  
+  mp.println("\nThis should only print on Serial_A and Serial_C\n");
+
+  mp.println("Done...\n");
 
 }
 

--- a/examples/Multiplex_test/Multiplex_test.ino
+++ b/examples/Multiplex_test/Multiplex_test.ino
@@ -1,7 +1,7 @@
 //
 //    FILE: Multiplex_test.ino
 //  AUTHOR: Rob Tillaart
-// VERSION: 0.1.0
+// VERSION: 0.2.0
 // PURPOSE: demo
 //    DATE: 2021-01-09
 
@@ -9,15 +9,45 @@
 
 Multiplex mp;
 
+class FakeStream : public Print
+{
+  public:
+  FakeStream(uint8_t id) : _id(id) { _id = id; };
+  
+  virtual size_t write(uint8_t c) override 
+  { 
+    return Serial.write(c);
+  };
+  
+  virtual size_t write(const uint8_t *buffer, size_t size) 
+  {
+    size_t n = 0;
+    n += Serial.print("stream");
+    n += Serial.print(_id, DEC);
+    n += Serial.print(':');
+        
+    for (uint8_t i = 0 ; i < size ; i++)
+    {
+      n += write(buffer[i]);
+    }
+    return n;
+  }
+  private: 
+  uint8_t _id = 0;
+};
+
 void setup()
 {
   Serial.begin(115200);
   Serial.println(__FILE__);
 
-  mp.add(&Serial);
-  mp.println("one");
-  mp.add(&Serial);
-  mp.println("two");
+  FakeStream stream1(1);
+  FakeStream stream2(2);
+
+  mp.add(&stream1);
+  mp.print("one\n");
+  mp.add(&stream2);
+  mp.print("two\n");
 
   for (int i = 0; i < mp.count(); i++)
   {
@@ -28,7 +58,7 @@ void setup()
   }
 
   mp.disable(1);
-  mp.println("three");
+  mp.print("three\n");
 
   for (int i = 0; i < mp.count(); i++)
   {
@@ -39,7 +69,7 @@ void setup()
   }
 
   mp.disable(0);
-  mp.println("four");
+  mp.print("four\n");
 
   for (int i = 0; i < mp.count(); i++)
   {
@@ -50,7 +80,22 @@ void setup()
   }
 
   mp.enable(0);
-  mp.println("\n Done...\n");
+  mp.enable(1);
+  mp.print("five\n");
+
+  mp.disableStream(&stream1);
+  mp.print("six\n");
+
+  mp.enableStream(&stream1);
+  for (int i = 0; i < mp.count(); i++)
+  {
+    Serial.print("isEnabled ");
+    Serial.print(i);
+    Serial.print(":\t");
+    Serial.println(mp.isEnabled(i));
+  }
+
+  mp.print("Done...\n");
 
 }
 

--- a/library.json
+++ b/library.json
@@ -15,7 +15,7 @@
     "type": "git",
     "url": "https://github.com/RobTillaart/Multiplex"
   },
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "frameworks": "arduino",
   "platforms": "*"

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Multiplex
-version=0.1.0
+version=0.2.0
 author=Rob Tillaart <rob.tillaart@gmail.com>
 maintainer=Rob Tillaart <rob.tillaart@gmail.com>
 sentence=Arduino Library implementing a stream multiplexer

--- a/test/unit_test_001.cpp
+++ b/test/unit_test_001.cpp
@@ -115,8 +115,8 @@ unittest(test_enable)
     assertTrue(mp.isEnabled(i));
   }
 
-  assertTrue(mp.isEnabled(&stream1));
-  assertTrue(mp.isEnabled(&stream2));
+  assertTrue(mp.isEnabledStream(&stream1));
+  assertTrue(mp.isEnabledStream(&stream2));
 
   mp.disableStream(&stream1);
   mp.disableStream(&stream2);

--- a/test/unit_test_001.cpp
+++ b/test/unit_test_001.cpp
@@ -35,7 +35,35 @@
 #include "Arduino.h"
 #include "Multiplex.h"
 
-
+// A simple implementation of Print that outputs
+// to Serial, prefixing each call to write(buffer, size)
+// with an id.
+class FakeStream : public Print
+{
+  public:
+  FakeStream(uint8_t id) : _id(id) { _id = id; };
+  
+  virtual size_t write(uint8_t c) override 
+  { 
+    return Serial.write(c);
+  };
+  
+  virtual size_t write(const uint8_t *buffer, size_t size) 
+  {
+    size_t n = 0;
+    n += Serial.print("stream");
+    n += Serial.print(_id, DEC);
+    n += Serial.print(':');
+        
+    for (uint8_t i = 0 ; i < size ; i++)
+    {
+      n += write(buffer[i]);
+    }
+    return n;
+  }
+  private: 
+  uint8_t _id = 0;
+};
 
 unittest_setup()
 {
@@ -54,8 +82,11 @@ unittest(test_constructor)
   assertEqual(0, mp.count());
   assertEqual(4, mp.size());
 
-  assertTrue(mp.add(&Serial));
-  assertTrue(mp.add(&Serial));
+  FakeStream stream1(1);
+  FakeStream stream2(2);
+
+  assertTrue(mp.add(&stream1));
+  assertTrue(mp.add(&stream2));
   assertEqual(2, mp.count());
   assertEqual(4, mp.size());
   
@@ -69,8 +100,11 @@ unittest(test_enable)
   fprintf(stderr, "VERSION: %s\n", MULTIPLEX_LIB_VERSION);
 
   Multiplex mp;
-  assertTrue(mp.add(&Serial));
-  assertTrue(mp.add(&Serial));
+  FakeStream stream1(1);
+  FakeStream stream2(2);
+
+  assertTrue(mp.add(&stream1));
+  assertTrue(mp.add(&stream2));
 
   for (int i = 0; i < mp.count(); i++)
   {
@@ -81,6 +115,14 @@ unittest(test_enable)
     assertTrue(mp.isEnabled(i));
   }
 
+  assertTrue(mp.isEnabled(&stream1));
+  assertTrue(mp.isEnabled(&stream2));
+
+  mp.disableStream(&stream1);
+  mp.disableStream(&stream2);
+
+  assertFalse(mp.isEnabledStream(&stream1));
+  assertFalse(mp.isEnabledStream(&stream2));
 }
 
 unittest_main()


### PR DESCRIPTION
Pretty straightforward.

Here's an example of how I'm using it:

```c++
  if (argc > 1 && !strcmp_P(argv[1], PSTR("on"))) {
    Cmds._multiplex.enable(shell.stream());
    shell.println(F("notify = on"));
  } else if (argc > 1 && !strcmp_P(argv[1], PSTR("off"))) {
    Cmds._multiplex.disable(shell.stream());
    shell.println(F("notify = off"));
  }
```